### PR TITLE
Add virtual pointer API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "embedded-touch"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "fixed",
  "fixed-macro",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embedded-touch"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 authors = ["Riley Williams <riley@rileyw.dev>"]
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # embedded-touch
 
-A `no_std` crate providing common interfaces for touchscreen input devices.
+The primary goal of this crate is to provide a common interface for UI libraries like
+[buoyant](https://crates.io/crates/buoyant) to interact with touchscreen input device
+drivers (e.g. `FT6113`).
 
 ## Features
 
@@ -11,14 +13,14 @@ A `no_std` crate providing common interfaces for touchscreen input devices.
 
 ## Usage
 
-Implement the `TouchScreen` trait for blocking operation:
+Implement the `TouchInputDevice` trait for blocking operation:
 
 ```rust
-use embedded_touch::{TouchScreen, Touch, Error};
+use embedded_touch::{TouchInputDevice, Touch, Error};
 
 struct MyTouchDriver { /* ... */ }
 
-impl TouchScreen for MyTouchDriver {
+impl TouchInputDevice for MyTouchDriver {
     type Error = MyError;
 
     fn touches(&mut self) -> Result<impl IntoIterator<Item = Touch>, Error<Self::Error>> {
@@ -27,12 +29,12 @@ impl TouchScreen for MyTouchDriver {
 }
 ```
 
-Or implement `AsyncTouchScreen` for event-driven operation:
+Or implement `AsyncTouchInputDevice` for event-driven operation:
 
 ```rust
-use embedded_touch::{AsyncTouchScreen, Touch, Error};
+use embedded_touch::{AsyncTouchInputDevice, Touch, Error};
 
-impl AsyncTouchScreen for MyTouchDriver {
+impl AsyncTouchInputDevice for MyTouchDriver {
     type Error = MyError;
 
     async fn touches(&mut self) -> Result<impl IntoIterator<Item = Touch>, Error<Self::Error>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! Common traits and types for touch screen drivers
+//! Common traits and types for touch screen drivers (and mice)
 
 #![no_std]
 
@@ -7,8 +7,8 @@ use core::fmt::Debug;
 use fixed::{traits::ToFixed, types::U17F15};
 use fixed_macro::types::{I17F15, U17F15};
 
-/// Blocking touch interface for touch screens
-pub trait TouchScreen {
+/// Blocking interface for touch devices.
+pub trait TouchInputDevice {
     /// Error type from the underlying interface
     type Error;
 
@@ -19,8 +19,8 @@ pub trait TouchScreen {
     fn touches(&mut self) -> Result<impl IntoIterator<Item = Touch>, Error<Self::Error>>;
 }
 
-/// Async touch screen interface for event-driven operation
-pub trait AsyncTouchScreen {
+/// Async interface for event-driven operation of touch devices
+pub trait AsyncTouchInputDevice {
     /// Error type from the underlying interface
     type Error;
 
@@ -69,6 +69,8 @@ pub enum Phase {
     Ended,
     /// Touch was cancelled (e.g., palm rejection triggered)
     Cancelled,
+    /// Touch is hovering above the screen without contact
+    Hovering,
 }
 
 /// Tool/instrument used for touch interaction
@@ -76,6 +78,11 @@ pub enum Phase {
 pub enum Tool {
     /// Finger or unknown tool
     Finger,
+    /// Virtual pointing device (e.g., mouse cursor)
+    Pointer {
+        /// The button pressed on the virtual pointer
+        button: PointerButton,
+    },
     /// Passive or active stylus
     Stylus {
         /// Pressure, in grams
@@ -89,6 +96,19 @@ pub enum Tool {
         /// 0 degrees points up to the top of the screen in its default orientation.
         azimuth: Option<UnitAngle>,
     },
+}
+
+/// The button state of a virtual pointer device
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PointerButton {
+    /// No button pressed, e.g., mouse hover state
+    None,
+    /// Primary mouse button, typically left
+    Primary,
+    /// Secondary mouse button, typically right
+    Secondary,
+    /// Tertiary mouse button, typically middle or wheel
+    Tertiary,
 }
 
 /// Error types for touch operations


### PR DESCRIPTION
Renames `TouchScreen` to the more generic `TouchInputDevice`.
Adds mouse support. This seems worth including as a somewhat second-class citizen. 
The primary goal of this API is to interface between drivers for ICs like the `FT3x68` series and embedded UI crates like `buoyant`