### PR TITLE
Moves x and y into a struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "embedded-touch"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "fixed",
  "fixed-macro",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embedded-touch"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 authors = ["Riley Williams <riley@rileyw.dev>"]
 license = "MIT OR Apache-2.0"

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,0 +1,27 @@
+use crate::Touch;
+
+/// Blocking interface for touch devices.
+pub trait TouchInputDevice {
+    /// Error type from the underlying interface
+    type Error;
+
+    /// Read current touch points, blocking until data is available
+    ///
+    /// Returns an iterator of *all* touch points currently detected.
+    /// Drivers must track touch IDs across calls to maintain correct phase information.
+    fn touches(&mut self) -> Result<impl IntoIterator<Item = &Touch>, Self::Error>;
+}
+
+/// Async interface for event-driven operation of touch devices
+pub trait AsyncTouchInputDevice {
+    /// Error type from the underlying interface
+    type Error;
+
+    /// Asynchronously wait until touch points are available
+    ///
+    /// Returns an iterator of *all* touch points currently detected.
+    /// Drivers must track touch IDs across calls to maintain correct phase information.
+    fn touches(
+        &mut self,
+    ) -> impl Future<Output = Result<impl IntoIterator<Item = &Touch>, Self::Error>>;
+}


### PR DESCRIPTION
- Wraps x and y in an object to allow deriving Into in other crates
- Removes the Error wrapper type